### PR TITLE
Update rgeo native extension build arguments

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -110,7 +110,7 @@ if [ -f $CACHE_DIR/.bundle/config ]; then
   rm $CACHE_DIR/.bundle/config
 fi
 echo "---
-BUNDLE_BUILD__RGEO: "--with-geos-dir=$BUILD_DIR/$TARGET_VENDOR_DIR --with-geos-lib=$BUILD_DIR/$TARGET_VENDOR_DIR/lib --with-proj-dir=$BUILD_DIR/$TARGET_VENDOR_DIR --with-proj-lib=$BUILD_DIR/$TARGET_VENDOR_DIR/lib"
+BUNDLE_BUILD__RGEO: "--with-opt-dir=$BUILD_DIR/$TARGET_VENDOR_DIR --with-geos-config=$BUILD_DIR/$TARGET_VENDOR_DIR/bin/geos-config"
 BUNDLE_FROZEN: '1'
 BUNDLE_PATH: vendor/bundle
 BUNDLE_BIN: vendor/bundle/bin


### PR DESCRIPTION
Previously, the rgeo build silently failed due to not being able to
link against required libraries. This is due to silently accepting but
ignoring the previously valid `--with-geos-dir` and friends.

At some point the option changed to `--with-opt-dir` plus needing
`--with-geos-config`, and this changes the build to reflect that.

This was deployed successfully with Ruby 2.1.2, Cedar 14, geos 3.4.2, rgeo 0.5.2, and bundler 1.9.7.
