### PR TITLE
Update command to set multibuildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 
 Example usage:
 
-    $ heroku config:add BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
+    $ heroku buildpacks:set https://github.com/ddollar/heroku-buildpack-multi.git
 
     $ cat .buildpacks
     https://github.com/cyberdelia/heroku-geo-buildpack.git#1.3


### PR DESCRIPTION
Looks like this command might have changed over time. Old version didn't work for me, but I found a newer command at https://github.com/ddollar/heroku-buildpack-multi that worked.