### PR TITLE
Don't assume the app is in /app, expose env variables to subsequent buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -22,6 +22,9 @@ BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 PROFILE_PATH="$BUILD_DIR/.profile.d/geo.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 
+# Set up exports file
+EXPORTS_PATH="$BP_DIR/export"
+
 # Functions
 function indent() {
   c='s/^/       /'
@@ -51,6 +54,10 @@ function set-env (){
 
 function set-default-env (){
   echo "export $1=\${$1:-$2}" >> $PROFILE_PATH
+}
+
+function set-export (){
+  echo "export $1=$2" >> $EXPORTS_PATH
 }
 
 # Retrieve versions
@@ -97,21 +104,28 @@ for dir in $VENDORED_GEOS $VENDORED_GDAL $VENDORED_PROJ; do
 done
 
 # App directories
-APP_VENDOR="$BUILD_DIR/$TARGET_VENDOR_DIR"
+APP_VENDOR_RUNTIME="$\HOME/$TARGET_VENDOR_DIR"
+APP_VENDOR_BUILD="$BUILD_DIR/$TARGET_VENDOR_DIR"
 
-# Setup environment variables
-set-env GEOS_LIBRARY_PATH "$APP_VENDOR/lib"
-set-env GDAL_LIBRARY_PATH "$APP_VENDOR/lib"
-set-env PROJ4_LIBRARY_PATH "$APP_VENDOR/lib"
-set-env GDAL_DATA "$APP_VENDOR/share/gdal"
+# Setup environment variables needed to run the app
+set-env GEOS_LIBRARY_PATH "$APP_VENDOR_RUNTIME/lib"
+set-env GDAL_LIBRARY_PATH "$APP_VENDOR_RUNTIME/lib"
+set-env PROJ4_LIBRARY_PATH "$APP_VENDOR_RUNTIME/lib"
+set-env GDAL_DATA "$APP_VENDOR_RUNTIME/share/gdal"
+set-default-env LIBRARY_PATH "$APP_VENDOR_RUNTIME/lib"
+set-default-env LD_LIBRARY_PATH "$APP_VENDOR_RUNTIME/lib"
+set-default-env CPATH "$APP_VENDOR_RUNTIME/include"
+set-default-env PATH "$APP_VENDOR_RUNTIME/bin"
 
-
-# Export env var for next build
-echo "BUNDLE_BUILD__RGEO=\"--with-opt-dir=$BUILD_DIR/$TARGET_VENDOR_DIR --with-geos-config=$BUILD_DIR/$TARGET_VENDOR_DIR/bin/geos-config\"" >> $BP_DIR/export
-set-default-env BUNDLE_BUILD__RGEO "--with-opt-dir=$TARGET_VENDOR_DIR --with-geos-config=$TARGET_VENDOR_DIR/bin/geos-config"
-set-default-env LIBRARY_PATH "$APP_VENDOR/lib"
-set-default-env LD_LIBRARY_PATH "$APP_VENDOR/lib"
-set-default-env CPATH "$APP_VENDOR/include"
-set-default-env PATH "$APP_VENDOR/bin"
+# Set up environment variables needed during the remainder of
+# the build process.. These can be read by subsequent buildpacks
+set-export GEOS_LIBRARY_PATH "$APP_VENDOR_BUILD/lib"
+set-export GDAL_LIBRARY_PATH "$APP_VENDOR_BUILD/lib"
+set-export PROJ4_LIBRARY_PATH "$APP_VENDOR_BUILD/lib"
+set-export GDAL_DATA "$APP_VENDOR_BUILD/share/gdal"
+set-export LIBRARY_PATH "$APP_VENDOR_BUILD/lib"
+set-export LD_LIBRARY_PATH "$APP_VENDOR_BUILD/lib"
+set-export CPATH "$APP_VENDOR_BUILD/include"
+set-export PATH "$APP_VENDOR_BUILD/bin:\$PATH"
 
 echo "-----> Vendoring geo libraries done"

--- a/bin/compile
+++ b/bin/compile
@@ -97,7 +97,7 @@ for dir in $VENDORED_GEOS $VENDORED_GDAL $VENDORED_PROJ; do
 done
 
 # App directories
-APP_VENDOR="/app/$TARGET_VENDOR_DIR"
+APP_VENDOR="$BUILD_DIR/$TARGET_VENDOR_DIR"
 
 # Setup environment variables
 set-env GEOS_LIBRARY_PATH "$APP_VENDOR/lib"


### PR DESCRIPTION
* Don't assume the root is going to be `/app`. There are some buildpacks out there that make other buildpacks run in subdirectories and this assumption breaks them.

* Expose environment variables to subsequent buildpacks (such as the Python one) so that they can also read them.

This seems to fix: #37 #39 #31 

It might be a good idea to also pull in: https://github.com/dschep/heroku-geo-buildpack/commit/5ae45e57353aab6a9fb2f0443e9ea0974d8b29ba

To fix support for `heroku-16`.