### PR TITLE
set-default-env doesn't set variables if they already exist

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ function set-env (){
 }
 
 function set-default-env (){
-  echo "export $1=\${$1:-$2}" >> $PROFILE_PATH
+  echo "export $1=\${$1:+$1:}$2" >> $PROFILE_PATH
 }
 
 # Retrieve versions


### PR DESCRIPTION
If `LIBRARY_PATH`, `LIBRARY_PATH`, `CPATH` or `PATH` are already set either via config var or through some other profile script then `set-default-env` will not set them to the given values.